### PR TITLE
Security fix: Make URL-PRESENTATION escape its body by default

### DIFF
--- a/src/views/types/presentations/url.lisp
+++ b/src/views/types/presentations/url.lisp
@@ -11,8 +11,22 @@
 	 function that accepts same parameters as
 	 'render-view-field-value'. The function is expected to render
 	 the body into the usual output stream. Its return value is
-	 ignored."))
-  (:documentation "Presents text as a url."))
+	 ignored.")
+   (escape :initform t
+	   :initarg :escape
+	   :accessor url-presentation-escape
+	   :documentation "If true (the default), the URL will be HTML-
+	   escaped on output to the page.")
+   (nofollow :initform nil
+	     :initarg :nofollow
+	     :accessor url-presentation-nofollow
+	     :documentation "If true, `rel=\"nofollow\" will be emitted to 
+	     tell search engines that this is a user-entered link that
+	     should not be considered in ranking the target."))
+  (:documentation "Presents text as a URL. The link body is normally HTML-
+  escaped; you can turn this off, if needed, by using `:escape nil',
+  or circumvent it with a body function.  The 'href' attribute is
+  not escaped; be careful to validate it in advance."))
 
 (defmethod render-view-field-value (value (presentation url-presentation)
 				    field view widget obj &rest args
@@ -22,10 +36,15 @@
       (call-next-method)
       (with-html
 	(:a :href value
+	    :rel (and (url-presentation-nofollow presentation) "nofollow")
 	    :onclick "stopPropagation(event);"
-	    (etypecase (url-presentation-body presentation)
-	      (string (str (url-presentation-body presentation)))
-	      (function (apply (url-presentation-body presentation)
-			       value presentation field view widget obj args))
-              (null (str value)))))))
+	    (flet ((out (x)
+		     (if (url-presentation-escape presentation)
+			 (esc x)
+		       (str x))))
+	      (etypecase (url-presentation-body presentation)
+		(string (out (url-presentation-body presentation)))
+		(function (apply (url-presentation-body presentation)
+				 value presentation field view widget obj args))
+		(null (out value))))))))
 


### PR DESCRIPTION
... with an option to turn it off.  This fixes a likely source of XSS bugs.

Also, added an option to generate rel="nofollow".
