### PR TITLE
Bug fix/feature: WITH-TRANSACTION

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -15,7 +15,7 @@
     (:shadowing-import-from :fare-matcher #:match)
     (:shadowing-import-from :metabang.utilities #:with-array #:size #:bind)
     (:shadowing-import-from :json #:prototype)
-    (:shadow #:redirect #:reset-sessions #:errors #:find-all)
+    (:shadow #:redirect #:reset-sessions #:errors #:find-all #:with-transaction)
     (:documentation
       "Weblocks is a Common Lisp framework that eases the pain of web
       application development. It achieves its goals by standardizing on

--- a/src/store/clsql/clsql.lisp
+++ b/src/store/clsql/clsql.lisp
@@ -3,6 +3,7 @@
   (:use :cl :metabang.utilities :clsql :weblocks)
   (:shadowing-import-from :metabang.utilities #:format-date #:filter
 			  #:print-date)
+  (:shadowing-import-from :weblocks #:with-transaction)
   (:documentation
    "A driver for weblocks backend store API that connects to CLSQL."))
 


### PR DESCRIPTION
I thought Weblocks should export a WITH-TRANSACTION macro to go with the
other functions in this file.  Implementing it, I noticed a bug in
DYNAMIC-TRANSACTION: it would commit, rather than rollback, on a nonlocal
exit out of the body if that exit wasn't done by signalling an error
(i.e. was done by THROW, RETURN, or GO).  I fixed this.  I guessed
that this was the "unique non-local exit unwind behavior" being warned
about, and removed the warning.
