### PR TITLE
Bug fix?: turn off sorting on table view field with :READER

### DIFF
--- a/src/views/sequence-view.lisp
+++ b/src/views/sequence-view.lisp
@@ -45,7 +45,7 @@ is no information available.")
 	     :documentation "If set to a symbol or a list of symbols,
 	     this slot will be used to build an order-by path that is
 	     later passed to the backend store for ordering the
-	     entires of the sequence. If this slot is unbound (the
+	     entries of the sequence. If this slot is unbound (the
 	     default), the 'slot-name' slot of the field will be used
 	     instead.")
    (allow-sorting-p :initform t
@@ -56,6 +56,15 @@ is no information available.")
   (:documentation "This is a class that can be mixed into field
   definitions in order to provide functionality necessary to support
   dataseq widgets."))
+
+;;; By default, turn off sorting on any field with a `reader', unless it also has
+;;; an `order-by'.
+(defmethod initialize-instance :after ((field view-field-sorting-mixin)
+				       &key allow-sorting-p &allow-other-keys)
+  (when (and (not allow-sorting-p)
+	     (slot-boundp field 'reader)
+	     (not (slot-boundp field 'order-by)))
+    (setf (view-field-sorting-mixin-allow-sorting-p field) nil)))
 
 
 ;;; Sequence view field

--- a/src/widgets/datagrid/sort.lisp
+++ b/src/widgets/datagrid/sort.lisp
@@ -20,7 +20,8 @@
                                      (attributize-view-field-name field-info)
                                      (attributize-name slot-name))
                                    th-class)
-	       (:span (render-link
+	       (:span :class "label"
+		      (render-link
 		       (make-action
 			(lambda (&rest args)
 			  (declare (ignore args))


### PR DESCRIPTION
By default, turn off sorting on any table view field with a :READER,
unless it also has an :ORDER-BY.  Prevents errors when the user attempts
to sort on that field.  (You could say :ALLOW-SORTING-P NIL yourself, but
this saves you the trouble.)

This isn't really a bug fix, but makes Weblocks a little easier to use by
preventing a likely class of app bugs.

Also, added a class to an HTML <span> that didn't have one.
