### PR TITLE
Turn Hunchentoot's *CATCH-ERRORS-P* off in debug mode.  This allows

### DIFF
--- a/src/debug-mode.lisp
+++ b/src/debug-mode.lisp
@@ -12,6 +12,7 @@
   (setf *weblocks-global-debug* t)
   ;; Set hunchentoot defaults (for everyone)
   (setf *show-lisp-errors-p* t)
+  (setf *catch-errors-p* nil)
   ;(setf *show-lisp-backtraces-p* t)
   ;; Set session maintenance (for everyone)
   (unless *maintain-last-session*
@@ -22,6 +23,7 @@
   "A manual method for resetting global debugging state"
   (setf *weblocks-global-debug* nil)
   (setf *show-lisp-errors-p* nil)
+  (setf *catch-errors-p* t)
   ;(setf *show-lisp-backtraces-p* nil)
   (setf *maintain-last-session* nil))
 


### PR DESCRIPTION
errors to be debugged in the Lisp session, rather than just dumping a
backtrace page to the browser.  (The backtrace page is no longer working
for some reason; personally, I greatly prefer to be able to debug in SLIME).
