### PR TITLE
Fixing weblocks backtrace on latest hunchentoot (1.2.3 and 1.2.5 at least)

### DIFF
--- a/src/acceptor.lisp
+++ b/src/acceptor.lisp
@@ -22,3 +22,6 @@
   (let ((*print-readably* nil))
     (call-next-method)))
 
+(when (function hunchentoot:acceptor-status-message)
+  (defmethod acceptor-status-message :around ((acceptor weblocks-acceptor) (http-status-code (eql 500)) &key &allow-other-keys)
+    nil))


### PR DESCRIPTION
Had the same failures counts when running tests before and after this patch. Haven't write a test for patch.
