### PR TITLE
Fixing google-chrome bug and maybe bugs in other browsers

### DIFF
--- a/src/request-handler.lisp
+++ b/src/request-handler.lisp
@@ -179,11 +179,13 @@ customize behavior."))
               (handle-normal-request app)))
           (eval-hook :post-render))
 
-	(unless (ajax-request-p)
-	  (setf (webapp-session-value 'last-request-uri) (all-tokens *uri-tokens*)))
+	
 
         (if (member (return-code*) *approved-return-codes*)
-          (get-output-stream-string *weblocks-output-stream*)
+          (progn 
+            (unless (ajax-request-p)
+              (setf (webapp-session-value 'last-request-uri) (all-tokens *uri-tokens*)))
+            (get-output-stream-string *weblocks-output-stream*))
           (handle-http-error app (return-code*)))))))
 
 (defmethod handle-ajax-request ((app weblocks-webapp))


### PR DESCRIPTION
google-chrome requested /favicon.ico for every page loaded. So last-request-uri contained wrong value  and refresh-request-p didn't work properly.
Code also should fix possible bugs with undocumented requests in other browsers.
Bug is covered in https://github.com/html/weblocks-selenium-tests (just set google-chrome as selenium browser in settings), to reproduce it refresh page when dialog is showing.
