### PR TITLE
Implement YIELD within WITH-FLOW correctly, so doesn't break if YIELD is

### DIFF
--- a/src/control-flow/workflow.lisp
+++ b/src/control-flow/workflow.lisp
@@ -3,14 +3,6 @@
 
 (export '(with-flow yield))
 
-(defun yield->do-widget (expr widget)
-  "Walks the expression tree and converts calls to 'yield' to
-appropriate calls to 'do-widget'."
-  (cond
-    ((atom expr) expr)
-    ((eq (car expr) 'yield) `(do-widget ,widget ,(cadr expr)))
-    (t (mapcar (curry-after #'yield->do-widget widget) expr))))
-
 (defmacro with-flow (widget &body body)
   "Eases the burden of creating flows. Instead of using 'do-widget' in
 the body, one can use 'yield', which will expand into appropriate
@@ -18,6 +10,8 @@ the body, one can use 'yield', which will expand into appropriate
   (let ((w (gensym)))
     `(let ((,w ,widget))
        (declare (ignorable ,w))
-       (with-call/cc
-	 ,@(yield->do-widget body w)))))
+       (macrolet ((yield (target)
+		    `(do-widget ,',w ,target)))
+	 (with-call/cc
+	   ,@body)))))
 


### PR DESCRIPTION
used as a variable or quoted symbol.  (That's admittedly unlikely, but this is the right way to do what Slava's trying to do here.)
