### PR TITLE
Dropdown presentation bug fix

### DIFF
--- a/src/views/types/presentations/choices.lisp
+++ b/src/views/types/presentations/choices.lisp
@@ -68,8 +68,28 @@ and returns a list as specified in the 'choices' slot."
                            (if (consp choice)
                                (cons (format nil "~A" (car choice))
                                      (format nil "~A" (cdr choice)))
-                               (cons (funcall (presentation-choices-label-key choices-mixin) choice)
-                                     (funcall (presentation-choices-value-key choices-mixin) choice))))
+                               (cons (princ-to-string
+                                      (funcall
+                                       (presentation-choices-label-key choices-mixin) choice))
+                                     (princ-to-string
+                                      (funcall
+                                       (presentation-choices-value-key choices-mixin) choice)))))
                          choices))))
     (obtain-presentation-choices-aux (presentation-choices choices-mixin) obj)))
 
+(defclass choices-parser (parser)
+  ()
+  (:documentation "A parser designed to handle choices."))
+
+(defmethod parse-view-field-value ((parser choices-parser) value obj
+                                   (view form-view) (field form-view-field) &rest args)
+  (declare (ignore args))
+  (let ((presentation
+         (view-field-presentation field)))
+  (values t
+          t
+          (find value
+                (funcall (presentation-choices presentation) obj)
+                :key (compose #'princ-to-string
+                              (presentation-choices-value-key presentation))
+                :test #'string=)))))

--- a/src/views/types/presentations/dropdown.lisp
+++ b/src/views/types/presentations/dropdown.lisp
@@ -33,7 +33,8 @@
                      :selected-value (if intermediate-value-p
                                          intermediate-value
                                          (when value
-                                           (presentation-choices-default-value-key value)))
+                                           (princ-to-string
+                                            (funcall
+                                             (presentation-choices-value-key presentation) value))))
                      :disabledp (form-view-field-disabled-p field obj)
                      :id *presentation-dom-id*)))
-


### PR DESCRIPTION
Hello!
- render-view-field-value for dropdown-presentation was called presentation-choices-default-value-key but expected presentation-choices-value-key;
- if we pass choices as alist in obtain-presentation-choices, then we receive alist where car and cdr values are strings, but if we pass not alist, our result alist cons contain values of any type. princ-to-string fixed this;
- implemented choices-parser to unify work with choices.