### PR TITLE
probe-file isn't required to accept a directory argument.

### DIFF
--- a/src/application.lisp
+++ b/src/application.lisp
@@ -572,7 +572,7 @@ the system specified by 'asdf-system-name', and goes into 'pub'."
                         (compute-public-files-path
                          (attributize-name
                           (weblocks-webapp-name app))))))
-            (if (and path (probe-file path))
+            (if (and path (fad:directory-exists-p path))
               (setf (weblocks-webapp-public-files-path app) path)
                 (progn
                   (and (weblocks-webapp-debug app) (not warned)


### PR DESCRIPTION
On CLISP it doesn't.
This fixes weblocks to not rely on Lisp implementation specific probe-file behaviour.