### PR TITLE
Make Weblocks load reliably

### DIFF
--- a/weblocks-util.asd
+++ b/weblocks-util.asd
@@ -31,7 +31,8 @@
                :trivial-backtrace 
                :parse-number 
                :pretty-function 
-               :ironclad)
+               :ironclad
+               :babel)
   :components 
     ((:module src
       :components (


### PR DESCRIPTION
src/utils/misc.lisp's md5 function references babel:string-to-octets.